### PR TITLE
Award Kudos: modal form, history, notifications and admin proof verifier UI

### DIFF
--- a/src/components/admin/KudosProofsDashboard.tsx
+++ b/src/components/admin/KudosProofsDashboard.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import Button from '@/components/common/Button';
+import Spinner from '@/components/common/Spinner';
+import UserCard from '@/components/users/UserCard';
+import { getImagePath } from '@/shared/api/config';
+import { timeAgoLabel } from '@/shared/timeAgoLabel';
+import {
+    useKudosAwardsInfinite,
+    type KudosAwardDTO,
+    type KudosAwardStatusFilter
+} from '@/shared/api/queries/kudosAwards';
+import { useVerifyKudosAward } from '@/shared/api/mutations/kudos';
+
+const STATUS_OPTIONS: Array<{
+    value: KudosAwardStatusFilter;
+    label: string;
+}> = [
+    { value: 'pending', label: 'Pending' },
+    { value: 'verified', label: 'Verified' },
+    { value: 'rejected', label: 'Rejected' },
+    { value: 'all', label: 'All' }
+];
+
+const STATUS_BADGES: Record<string, string> = {
+    pending:
+        'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+    verified:
+        'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+    rejected: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+};
+
+function AwardCard({ award }: { award: KudosAwardDTO }) {
+    const verifyMutation = useVerifyKudosAward();
+    const status = award.verificationStatus ?? 'pending';
+
+    const resolve = async (action: 'verify' | 'reject') => {
+        if (
+            action === 'reject' &&
+            !window.confirm(
+                `Reject this award? ${award.amount} kudos will be returned to the giver.`
+            )
+        ) {
+            return;
+        }
+        await verifyMutation.mutateAsync({ giftID: award.giftID, action });
+    };
+
+    return (
+        <div
+            className='p-4 border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-900 space-y-3'
+            data-testid='kudos-proof-card'
+        >
+            <div className='flex items-start justify-between gap-3'>
+                <div className='space-y-1'>
+                    <div className='flex items-center gap-2 flex-wrap'>
+                        <span className='inline-flex items-center rounded-full px-2.5 py-0.5 text-sm font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'>
+                            {award.amount} Kudos
+                        </span>
+                        <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                                STATUS_BADGES[status] ?? ''
+                            }`}
+                            data-testid='kudos-proof-status'
+                        >
+                            {status}
+                        </span>
+                    </div>
+                    {award.title ? (
+                        <p className='text-sm font-semibold text-gray-900 dark:text-gray-100 break-words'>
+                            “{award.title}”
+                        </p>
+                    ) : null}
+                    {award.description ? (
+                        <p className='text-sm text-gray-600 dark:text-gray-400 break-words'>
+                            {award.description}
+                        </p>
+                    ) : null}
+                </div>
+                <span className='text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap'>
+                    {timeAgoLabel(award.createdAt)}
+                </span>
+            </div>
+
+            <div className='flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 flex-wrap'>
+                {award.giver ? (
+                    <>
+                        <span>from</span>
+                        <UserCard
+                            user={award.giver as any}
+                            triggerVariant='name'
+                            className='text-xs'
+                        />
+                    </>
+                ) : null}
+                {award.recipient ? (
+                    <>
+                        <span>to</span>
+                        <UserCard
+                            user={award.recipient as any}
+                            triggerVariant='name'
+                            className='text-xs'
+                        />
+                    </>
+                ) : null}
+            </div>
+
+            {award.attachments.length ? (
+                <div className='flex flex-wrap gap-2'>
+                    {award.attachments.map((url, idx) => {
+                        const src = getImagePath(url);
+                        if (!src) return null;
+                        return (
+                            <a
+                                key={`${url}-${idx}`}
+                                href={src}
+                                target='_blank'
+                                rel='noreferrer'
+                            >
+                                <img
+                                    src={src}
+                                    alt={`Evidence ${idx + 1}`}
+                                    className='w-24 h-24 object-cover rounded-lg border border-gray-200 dark:border-zinc-700'
+                                />
+                            </a>
+                        );
+                    })}
+                </div>
+            ) : (
+                <p className='text-xs italic text-gray-400 dark:text-gray-500'>
+                    No photographic evidence attached.
+                </p>
+            )}
+
+            {status === 'pending' && (
+                <div className='flex gap-2 pt-1'>
+                    <Button
+                        variant='success'
+                        data-testid='kudos-proof-verify'
+                        disabled={verifyMutation.isPending}
+                        onClick={() => resolve('verify')}
+                    >
+                        Verify
+                    </Button>
+                    <Button
+                        variant='danger'
+                        data-testid='kudos-proof-reject'
+                        disabled={verifyMutation.isPending}
+                        onClick={() => resolve('reject')}
+                    >
+                        Reject & refund
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function KudosProofsDashboard() {
+    const [status, setStatus] =
+        React.useState<KudosAwardStatusFilter>('pending');
+    const {
+        data,
+        isLoading,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage
+    } = useKudosAwardsInfinite(status);
+
+    if (isLoading) return <Spinner text='Loading kudos awards…' />;
+    if (error)
+        return <p className='text-red-600'>Error loading kudos awards</p>;
+
+    const awards = (data?.pages ?? []).flatMap((p) => p.data ?? []);
+
+    return (
+        <div className='space-y-4'>
+            <div className='flex items-center justify-between gap-3 flex-wrap'>
+                <div>
+                    <h2 className='text-xl font-semibold'>
+                        Kudos award proofs
+                    </h2>
+                    <p className='text-sm text-gray-500 dark:text-gray-400'>
+                        Peer awards document past gifts or help that happened
+                        off the website. Review the evidence; rejecting an
+                        award returns the kudos to the giver.
+                    </p>
+                </div>
+                <label className='text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2'>
+                    <span>Status:</span>
+                    <select
+                        className='border border-gray-200 dark:border-zinc-700 rounded px-3 py-1.5 bg-white dark:bg-zinc-800 text-gray-900 dark:text-gray-100'
+                        value={status}
+                        data-testid='kudos-proof-status-filter'
+                        onChange={(e) =>
+                            setStatus(
+                                e.target.value as KudosAwardStatusFilter
+                            )
+                        }
+                    >
+                        {STATUS_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+            </div>
+
+            {!awards.length ? (
+                <p className='text-gray-500' data-testid='kudos-proofs-empty'>
+                    No kudos awards for this filter.
+                </p>
+            ) : (
+                <div className='space-y-3'>
+                    {awards.map((award) => (
+                        <AwardCard key={award.giftID} award={award} />
+                    ))}
+                    {hasNextPage ? (
+                        <div className='text-center'>
+                            <Button
+                                variant='ghost'
+                                onClick={() => fetchNextPage()}
+                                disabled={isFetchingNextPage}
+                            >
+                                {isFetchingNextPage
+                                    ? 'Loading…'
+                                    : 'Load more'}
+                            </Button>
+                        </div>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/KudosProofsDashboard.tsx
+++ b/src/components/admin/KudosProofsDashboard.tsx
@@ -37,7 +37,7 @@ function AwardCard({ award }: { award: KudosAwardDTO }) {
         if (
             action === 'reject' &&
             !window.confirm(
-                `Reject this award? ${award.amount} kudos will be returned to the giver.`
+                `Reject this award? ${award.amount} kudos will be removed from the recipient.`
             )
         ) {
             return;
@@ -147,7 +147,7 @@ function AwardCard({ award }: { award: KudosAwardDTO }) {
                         disabled={verifyMutation.isPending}
                         onClick={() => resolve('reject')}
                     >
-                        Reject & refund
+                        Reject & revoke
                     </Button>
                 </div>
             )}
@@ -183,7 +183,7 @@ export default function KudosProofsDashboard() {
                     <p className='text-sm text-gray-500 dark:text-gray-400'>
                         Peer awards document past gifts or help that happened
                         off the website. Review the evidence; rejecting an
-                        award returns the kudos to the giver.
+                        award removes the kudos from the recipient.
                     </p>
                 </div>
                 <label className='text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2'>

--- a/src/components/notifications/NotificationsBell.tsx
+++ b/src/components/notifications/NotificationsBell.tsx
@@ -803,7 +803,10 @@ export default function NotificationsBell() {
                                                                     {'feedbackID' in n &&
                                                         (n as any).feedbackID
                                                                         ? 'Your feedback was resolved'
-                                                                        : 'Someone gave you kudos'}
+                                                                        : (n as any).user
+                                                                            ?.username
+                                                                            ? `${(n as any).user.username} awarded you kudos`
+                                                                            : 'Someone gave you kudos'}
                                                                 </div>
                                                                 <div className='text-xs text-zinc-500 dark:text-zinc-500 whitespace-nowrap mt-0.5'>
                                                                     {formatTimeAgo(n)}

--- a/src/components/users/AwardKudosModal.tsx
+++ b/src/components/users/AwardKudosModal.tsx
@@ -8,7 +8,6 @@ import Button from '@/components/common/Button';
 import Input from '@/components/forms/Input';
 import Form from '@/components/forms/Form';
 import FormField from '@/components/forms/FormField';
-import { useAuth } from '@/contexts/useAuth';
 import { useAwardKudos } from '@/shared/api/mutations/kudos';
 import { UserDTO } from '@/shared/api/types';
 import { ensureJpegAll } from '@/shared/convertHeic';
@@ -41,9 +40,10 @@ export function KudosInfoTooltip({
                     Awarding kudos is for thanking someone for{' '}
                     <span className='font-semibold'>past gifts</span> or help
                     that happened <span className='font-semibold'>outside
-                    the website</span> — no post or handshake needed. The
-                    kudos come out of your own balance, and photo evidence
-                    helps our admins verify the award.
+                    the website</span> — no post or handshake needed. Kudos
+                    are freely given — awarding doesn&apos;t reduce your own
+                    kudos — and photo evidence helps our admins verify the
+                    award.
                 </div>
             )}
         >
@@ -61,8 +61,6 @@ export default function AwardKudosModal({
     onClose: () => void;
     recipient: UserDTO;
 }) {
-    const { user: currentUser } = useAuth();
-    const balance = currentUser?.kudos ?? 0;
     const awardMutation = useAwardKudos();
 
     const form = useForm<FormValues>({
@@ -127,11 +125,11 @@ export default function AwardKudosModal({
         >
             <div className='flex items-center gap-1.5 mb-3 text-sm text-gray-600 dark:text-gray-300'>
                 <span data-testid='award-kudos-balance'>
-                    You have{' '}
+                    Kudos are{' '}
                     <span className='font-semibold text-teal-600 dark:text-teal-300'>
-                        {balance} kudos
+                        freely given
                     </span>{' '}
-                    to give.
+                    — awarding doesn&apos;t cost you anything.
                 </span>
                 <KudosInfoTooltip>
                     <button
@@ -201,8 +199,12 @@ export default function AwardKudosModal({
                                 const n = Number(value);
                                 if (!Number.isInteger(n) || n <= 0)
                                     return 'Kudos must be a positive whole number';
-                                if (n > balance)
-                                    return `You only have ${balance} kudos`;
+                                // Kudos are freely given, not spent from a balance.
+                                // Re-enable to cap awards by the giver's kudos
+                                // (pair with the commented debit in the backend):
+                                // const balance = useAuth().user?.kudos ?? 0;
+                                // if (n > balance)
+                                //     return `You only have ${balance} kudos`;
                                 return true;
                             }
                         }}

--- a/src/components/users/AwardKudosModal.tsx
+++ b/src/components/users/AwardKudosModal.tsx
@@ -124,21 +124,15 @@ export default function AwardKudosModal({
             title={`Award kudos to ${recipient.username ?? 'this user'}`}
         >
             <div className='flex items-center gap-1.5 mb-3 text-sm text-gray-600 dark:text-gray-300'>
-                <span data-testid='award-kudos-balance'>
-                    Kudos are{' '}
-                    <span className='font-semibold text-teal-600 dark:text-teal-300'>
-                        freely given
-                    </span>{' '}
-                    — awarding doesn&apos;t cost you anything.
-                </span>
                 <KudosInfoTooltip>
                     <button
                         type='button'
                         aria-label='What is awarding kudos?'
                         data-testid='kudos-info-trigger'
-                        className='p-0.5 rounded-full text-gray-400 hover:text-gray-600 dark:hover:text-gray-200'
+                        className='inline-flex items-center gap-1 p-0.5 rounded-full text-gray-400 hover:text-gray-600 dark:hover:text-gray-200'
                     >
                         <QuestionMarkCircleIcon className='w-4 h-4' />
+                        <span>What is this?</span>
                     </button>
                 </KudosInfoTooltip>
             </div>

--- a/src/components/users/AwardKudosModal.tsx
+++ b/src/components/users/AwardKudosModal.tsx
@@ -1,0 +1,276 @@
+import React from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import Tippy from '@tippyjs/react/headless';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+
+import Modal from '@/components/common/Modal';
+import Button from '@/components/common/Button';
+import Input from '@/components/forms/Input';
+import Form from '@/components/forms/Form';
+import FormField from '@/components/forms/FormField';
+import { useAuth } from '@/contexts/useAuth';
+import { useAwardKudos } from '@/shared/api/mutations/kudos';
+import { UserDTO } from '@/shared/api/types';
+import { ensureJpegAll } from '@/shared/convertHeic';
+import { takeFilesFromInput } from '@/shared/takeFilesFromInput';
+
+const MAX_FILE_COUNT = 5;
+const MAX_FILE_SIZE_MB = 10;
+
+type FormValues = {
+    title: string;
+    description: string;
+    amount: number | string;
+};
+
+export function KudosInfoTooltip({
+    children
+}: {
+    children: React.ReactElement;
+}) {
+    return (
+        <Tippy
+            placement='top'
+            delay={[100, 0]}
+            render={(attrs) => (
+                <div
+                    {...attrs}
+                    data-testid='kudos-info-tooltip'
+                    className='max-w-xs bg-black text-white text-xs rounded-lg px-3 py-2 leading-relaxed shadow-lg'
+                >
+                    Awarding kudos is for thanking someone for{' '}
+                    <span className='font-semibold'>past gifts</span> or help
+                    that happened <span className='font-semibold'>outside
+                    the website</span> — no post or handshake needed. The
+                    kudos come out of your own balance, and photo evidence
+                    helps our admins verify the award.
+                </div>
+            )}
+        >
+            {children}
+        </Tippy>
+    );
+}
+
+export default function AwardKudosModal({
+    open,
+    onClose,
+    recipient
+}: {
+    open: boolean;
+    onClose: () => void;
+    recipient: UserDTO;
+}) {
+    const { user: currentUser } = useAuth();
+    const balance = currentUser?.kudos ?? 0;
+    const awardMutation = useAwardKudos();
+
+    const form = useForm<FormValues>({
+        mode: 'onBlur',
+        defaultValues: { title: '', description: '', amount: '' }
+    });
+
+    const [selectedImages, setSelectedImages] = React.useState<File[]>([]);
+    const [fileError, setFileError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (open) {
+            form.reset({ title: '', description: '', amount: '' });
+            setSelectedImages([]);
+            setFileError(null);
+        }
+    }, [open, form]);
+
+    const handleImageUpload = async (
+        e: React.ChangeEvent<HTMLInputElement>
+    ) => {
+        const raw = takeFilesFromInput(e.target);
+        if (!raw.length) return;
+        const converted = await ensureJpegAll(raw);
+        const updated = [...selectedImages, ...converted];
+        if (updated.length > MAX_FILE_COUNT) {
+            setFileError(`Max ${MAX_FILE_COUNT} photos allowed.`);
+            return;
+        }
+        const tooLarge = updated.find(
+            (f) => f.size > MAX_FILE_SIZE_MB * 1024 * 1024
+        );
+        if (tooLarge) {
+            setFileError(`Photos must be under ${MAX_FILE_SIZE_MB}MB.`);
+            return;
+        }
+        setSelectedImages(updated);
+        setFileError(null);
+    };
+
+    const removeImage = (idx: number) =>
+        setSelectedImages((prev) => prev.filter((_, i) => i !== idx));
+
+    const onSubmit: SubmitHandler<FormValues> = async (data) => {
+        await awardMutation.mutateAsync({
+            recipientID: recipient.id,
+            title: data.title,
+            description: data.description || undefined,
+            amount: Number(data.amount),
+            files: selectedImages
+        });
+        form.reset({ title: '', description: '', amount: '' });
+        setSelectedImages([]);
+        onClose();
+    };
+
+    return (
+        <Modal
+            open={open}
+            onClose={onClose}
+            title={`Award kudos to ${recipient.username ?? 'this user'}`}
+        >
+            <div className='flex items-center gap-1.5 mb-3 text-sm text-gray-600 dark:text-gray-300'>
+                <span data-testid='award-kudos-balance'>
+                    You have{' '}
+                    <span className='font-semibold text-teal-600 dark:text-teal-300'>
+                        {balance} kudos
+                    </span>{' '}
+                    to give.
+                </span>
+                <KudosInfoTooltip>
+                    <button
+                        type='button'
+                        aria-label='What is awarding kudos?'
+                        data-testid='kudos-info-trigger'
+                        className='p-0.5 rounded-full text-gray-400 hover:text-gray-600 dark:hover:text-gray-200'
+                    >
+                        <QuestionMarkCircleIcon className='w-4 h-4' />
+                    </button>
+                </KudosInfoTooltip>
+            </div>
+
+            <Form methods={form} onSubmit={onSubmit} className='space-y-3'>
+                <FormField name='title' label='Title *' noMargin>
+                    <Input
+                        name='title'
+                        label=''
+                        showLabel={false}
+                        noMargin
+                        form={form}
+                        registerOptions={{
+                            required: 'Title is required',
+                            minLength: {
+                                value: 3,
+                                message:
+                                    'Title must be at least 3 characters'
+                            },
+                            maxLength: {
+                                value: 150,
+                                message:
+                                    'Title must be under 150 characters'
+                            }
+                        }}
+                        placeholder='e.g. Helped me move houses'
+                    />
+                </FormField>
+                <FormField name='description' label='Description' noMargin>
+                    <Input
+                        name='description'
+                        label=''
+                        showLabel={false}
+                        noMargin
+                        form={form}
+                        multiline
+                        registerOptions={{
+                            maxLength: {
+                                value: 4000,
+                                message:
+                                    'Description must be under 4000 characters'
+                            }
+                        }}
+                        placeholder='What did they do for you?'
+                    />
+                </FormField>
+                <FormField name='amount' label='Kudos to award *' noMargin>
+                    <Input
+                        name='amount'
+                        label=''
+                        showLabel={false}
+                        noMargin
+                        form={form}
+                        htmlInputType='number'
+                        registerOptions={{
+                            required: 'Enter how many kudos to award',
+                            validate: (value: unknown) => {
+                                const n = Number(value);
+                                if (!Number.isInteger(n) || n <= 0)
+                                    return 'Kudos must be a positive whole number';
+                                if (n > balance)
+                                    return `You only have ${balance} kudos`;
+                                return true;
+                            }
+                        }}
+                        placeholder='e.g. 25'
+                    />
+                </FormField>
+
+                <div>
+                    <label className='block text-sm font-semibold mb-2 text-gray-800 dark:text-gray-200'>
+                        Photographic evidence (optional)
+                    </label>
+                    <input
+                        type='file'
+                        accept='image/*'
+                        multiple
+                        data-testid='award-kudos-files'
+                        onChange={handleImageUpload}
+                    />
+                    {fileError && (
+                        <p
+                            className='mt-1 text-sm text-red-600 dark:text-red-400'
+                            data-testid='award-kudos-file-error'
+                        >
+                            {fileError}
+                        </p>
+                    )}
+                    {selectedImages.length > 0 && (
+                        <div className='mt-2 flex flex-wrap gap-2'>
+                            {selectedImages.map((file, idx) => (
+                                <div
+                                    key={`${file.name}-${idx}`}
+                                    className='relative'
+                                    data-testid='award-kudos-preview'
+                                >
+                                    <img
+                                        src={URL.createObjectURL(file)}
+                                        alt={`Evidence ${idx + 1}`}
+                                        className='w-16 h-16 object-cover rounded-lg border border-gray-200 dark:border-zinc-700'
+                                    />
+                                    <button
+                                        type='button'
+                                        aria-label={`Remove photo ${idx + 1}`}
+                                        data-testid={`award-kudos-remove-${idx}`}
+                                        onClick={() => removeImage(idx)}
+                                        className='absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-600 text-white text-xs leading-none flex items-center justify-center'
+                                    >
+                                        ×
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                <div className='flex justify-end gap-2'>
+                    <Button variant='ghost' onClick={onClose} type='button'>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant='primary'
+                        type='submit'
+                        data-testid='award-kudos-submit'
+                        disabled={awardMutation.isPending}
+                    >
+                        {awardMutation.isPending ? 'Awarding…' : 'Award kudos'}
+                    </Button>
+                </div>
+            </Form>
+        </Modal>
+    );
+}

--- a/src/components/users/KudosHistory.tsx
+++ b/src/components/users/KudosHistory.tsx
@@ -8,6 +8,7 @@ import {
     type KudosHistorySourceFilter
 } from '@/shared/api/queries/kudosHistory';
 import { timeAgoLabel } from '@/shared/timeAgoLabel';
+import { getImagePath } from '@/shared/api/config';
 import UserCard from './UserCard';
 
 const FILTER_OPTIONS: Array<{
@@ -18,7 +19,8 @@ const FILTER_OPTIONS: Array<{
     { value: 'donation', label: 'Donations' },
     { value: 'feedback', label: 'Feedback' },
     { value: 'report', label: 'Bug reports' },
-    { value: 'reward-offer', label: 'Reward offers' }
+    { value: 'reward-offer', label: 'Reward offers' },
+    { value: 'gift', label: 'Kudos awards' }
 ];
 
 const SOURCE_LABELS: Record<KudosHistoryDTO['source'], string> = {
@@ -26,7 +28,29 @@ const SOURCE_LABELS: Record<KudosHistoryDTO['source'], string> = {
     feedback: 'Feedback',
     report: 'Bug report',
     'reward-offer': 'Reward offer',
+    gift: 'Kudos award',
     other: 'Kudos update'
+};
+
+const VERIFICATION_BADGES: Record<
+    string,
+    { label: string; className: string }
+> = {
+    pending: {
+        label: 'Pending verification',
+        className:
+            'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+    },
+    verified: {
+        label: 'Verified',
+        className:
+            'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+    },
+    rejected: {
+        label: 'Rejected',
+        className:
+            'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+    }
 };
 
 function formatCurrencyFromCents(value?: unknown) {
@@ -41,6 +65,72 @@ function formatCurrencyFromCents(value?: unknown) {
 
 function renderDetail(item: KudosHistoryDTO): React.ReactNode {
     const metadata = (item.metadata ?? {}) as Record<string, unknown>;
+
+    if (item.source === 'gift') {
+        const title = metadata.title ? String(metadata.title) : null;
+        const description = metadata.description
+            ? String(metadata.description)
+            : null;
+        const attachments = Array.isArray(metadata.attachments)
+            ? (metadata.attachments as string[])
+            : [];
+        const status = metadata.verificationStatus
+            ? String(metadata.verificationStatus)
+            : null;
+        const badge = status ? VERIFICATION_BADGES[status] : null;
+        const isReceived = item.delta > 0;
+
+        return (
+            <div className='space-y-1' data-testid='kudos-gift-detail'>
+                <p className='text-sm text-gray-700 dark:text-gray-300'>
+                    {isReceived
+                        ? 'Kudos awarded to you for a past gift'
+                        : 'You awarded kudos for a past gift'}
+                </p>
+                {title ? (
+                    <p className='text-sm font-semibold text-gray-900 dark:text-gray-100 break-words'>
+                        “{title}”
+                    </p>
+                ) : null}
+                {description ? (
+                    <p className='text-xs text-gray-500 dark:text-gray-400 italic break-words'>
+                        “{description}”
+                    </p>
+                ) : null}
+                {attachments.length ? (
+                    <div className='flex flex-wrap gap-1.5 pt-1'>
+                        {attachments.map((url, idx) => {
+                            const src = getImagePath(url);
+                            if (!src) return null;
+                            return (
+                                <a
+                                    key={`${url}-${idx}`}
+                                    href={src}
+                                    target='_blank'
+                                    rel='noreferrer'
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <img
+                                        src={src}
+                                        alt={`Evidence ${idx + 1}`}
+                                        className='w-12 h-12 object-cover rounded border border-gray-200 dark:border-zinc-700'
+                                    />
+                                </a>
+                            );
+                        })}
+                    </div>
+                ) : null}
+                {badge ? (
+                    <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badge.className}`}
+                        data-testid='kudos-gift-verification'
+                    >
+                        {badge.label}
+                    </span>
+                ) : null}
+            </div>
+        );
+    }
 
     if (item.source === 'donation') {
         const amountLabel = formatCurrencyFromCents(metadata.amount);
@@ -255,7 +345,12 @@ export default React.memo(function KudosHistoryList({
                                         className='mt-2 flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400'
                                         onClick={(e) => e.stopPropagation()}
                                     >
-                                        <span>from</span>
+                                        <span>
+                                            {item.source === 'gift' &&
+                                            item.delta < 0
+                                                ? 'to'
+                                                : 'from'}
+                                        </span>
                                         <UserCard
                                             user={item.actor}
                                             triggerVariant='name'

--- a/src/components/users/Profile.tsx
+++ b/src/components/users/Profile.tsx
@@ -21,6 +21,9 @@ import UserCard from '@/components/users/UserCard';
 import { useBlockedUsers } from '@/contexts/useBlockedUsers';
 import Button from '../common/Button';
 import ReportPastGiftModal from '@/components/users/ReportPastGiftModal';
+import AwardKudosModal, {
+    KudosInfoTooltip
+} from '@/components/users/AwardKudosModal';
 import InviteManager from './InviteManager';
 import {
     resetFileInputBeforeOpen,
@@ -44,6 +47,7 @@ const Profile: React.FC<Props> = ({ user, setUser, hideBackButton = false, hideW
     const [showBlockedUsers, setShowBlockedUsers] = useState(false);
 
     const [showPastGiftModal, setShowPastGiftModal] = useState(false);
+    const [showAwardKudosModal, setShowAwardKudosModal] = useState(false);
     const [showReportModal, setShowReportModal] = useState(false);
     const [showBanModal, setShowBanModal] = useState(false);
     const [masqueradeLoading, setMasqueradeLoading] = useState(false);
@@ -201,6 +205,19 @@ const Profile: React.FC<Props> = ({ user, setUser, hideBackButton = false, hideW
             {!isSelf && (
                 <div className='flex justify-center'>
                     <div className='flex gap-3'>
+                        {currentUser && (
+                            <KudosInfoTooltip>
+                                <Button
+                                    onClick={() =>
+                                        setShowAwardKudosModal(true)
+                                    }
+                                    variant='primary'
+                                    data-testid='award-kudos'
+                                >
+                                    Award Kudos
+                                </Button>
+                            </KudosInfoTooltip>
+                        )}
                         <Button
                             onClick={() => setShowReportModal(true)}
                             className='!bg-red-600 !text-white'
@@ -424,6 +441,14 @@ const Profile: React.FC<Props> = ({ user, setUser, hideBackButton = false, hideW
                 onClose={() => setShowPastGiftModal(false)}
                 receiverID={user.id}
             />
+
+            {!isSelf && (
+                <AwardKudosModal
+                    open={showAwardKudosModal}
+                    onClose={() => setShowAwardKudosModal(false)}
+                    recipient={user}
+                />
+            )}
 
             {showReportModal && (
                 <div className='fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center'>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/contexts/useAuth';
 import { apiGet } from '@/shared/api/apiClient';
 import ReportsDashboard from '@/components/admin/ReportsDashboard';
 import FeedbackDashboard from '@/components/admin/FeedbackDashboard';
+import KudosProofsDashboard from '@/components/admin/KudosProofsDashboard';
 import AdminAnalytics from '@/components/admin/AdminAnalytics';
 import UserCard from '@/components/users/UserCard';
 import Tippy from '@tippyjs/react/headless';
@@ -15,7 +16,7 @@ export default function AdminDashboard() {
     const { user } = useAuth();
 
     const [tab, setTab] = useState<
-        'reports' | 'feedback' | 'analytics' | 'suspicious'
+        'reports' | 'feedback' | 'kudos-proofs' | 'analytics' | 'suspicious'
     >('reports');
 
     const [reports, setReports] = useState<any[]>([]);
@@ -82,6 +83,13 @@ export default function AdminDashboard() {
                         Feedback
                     </Button>
                     <Button
+                        variant={tab === 'kudos-proofs' ? 'primary' : 'ghost'}
+                        onClick={() => setTab('kudos-proofs')}
+                        data-testid='admin-tab-kudos-proofs'
+                    >
+                        Kudos Proofs
+                    </Button>
+                    <Button
                         variant={tab === 'analytics' ? 'primary' : 'ghost'}
                         onClick={() => setTab('analytics')}
                     >
@@ -105,6 +113,7 @@ export default function AdminDashboard() {
                     setFeedbacks={setFeedbacks}
                 />
             )}
+            {tab === 'kudos-proofs' && <KudosProofsDashboard />}
             {tab === 'analytics' && <AdminAnalytics />}
             {tab === 'suspicious' && (
                 <div>

--- a/src/pages/notifications/index.tsx
+++ b/src/pages/notifications/index.tsx
@@ -675,10 +675,13 @@ function describeNotification(
                 'feedbackID' in notification &&
                 !!(notification as any).feedbackID;
         const hasAmount = typeof amount === 'number' && amount > 0;
+        const giverName = (notification as any).user?.username;
         return {
             title: fromFeedback
                 ? 'Your feedback was resolved'
-                : 'Someone gave you kudos',
+                : giverName
+                    ? `${giverName} awarded you kudos`
+                    : 'Someone gave you kudos',
             description: hasAmount
                 ? `You received ${amount} kudos!`
                 : 'You received kudos!'

--- a/src/shared/api/mutations/kudos.ts
+++ b/src/shared/api/mutations/kudos.ts
@@ -90,7 +90,7 @@ export function useVerifyKudosAward() {
                 message:
                     result.verificationStatus === 'verified'
                         ? 'Award verified.'
-                        : 'Award rejected — kudos returned.'
+                        : 'Award rejected — kudos revoked.'
             });
         },
         onError: (err) => {

--- a/src/shared/api/mutations/kudos.ts
+++ b/src/shared/api/mutations/kudos.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiMutate } from '@/shared/api/apiClient';
+import { pushAlert } from '@/components/common/alertBus';
+import type { UserDTO } from '@/shared/api/types';
+
+export type AwardKudosPayload = {
+    recipientID: number;
+    title: string;
+    description?: string;
+    amount: number;
+    files?: File[];
+};
+
+export type AwardKudosResult = {
+    giftID: string;
+    amount: number;
+    title: string;
+    description: string | null;
+    attachments: string[];
+    verificationStatus: 'pending' | 'verified' | 'rejected';
+    recipientID: number;
+    giverID: number;
+    giverTotal: number;
+    recipientTotal: number;
+};
+
+function extractErrMessage(err: any): string {
+    if (Array.isArray(err) && err.every((s) => typeof s === 'string')) {
+        return err.join(', ');
+    }
+
+    return (
+        err?.response?.data?.errors?.[0]?.message ||
+        err?.response?.data?.message ||
+        err?.message ||
+        'Something went wrong'
+    );
+}
+
+export function useAwardKudos() {
+    const qc = useQueryClient();
+
+    return useMutation<AwardKudosResult, Error, AwardKudosPayload>({
+        mutationFn: (payload) =>
+            apiMutate<AwardKudosResult, AwardKudosPayload>(
+                '/kudos/award',
+                'post',
+                payload,
+                { as: 'form' }
+            ),
+        onSuccess: (result) => {
+            qc.invalidateQueries({ queryKey: ['kudos-history'] });
+            qc.invalidateQueries({ queryKey: ['user', result.recipientID] });
+            qc.setQueriesData<UserDTO | undefined>(
+                { queryKey: ['user', result.recipientID] },
+                (prev) =>
+                    prev ? { ...prev, kudos: result.recipientTotal } : prev
+            );
+            pushAlert({
+                type: 'success',
+                message: `Awarded ${result.amount} kudos!`
+            });
+        },
+        onError: (err) => {
+            pushAlert({ type: 'danger', message: extractErrMessage(err) });
+        }
+    });
+}
+
+export type KudosAwardVerdict = 'verify' | 'reject';
+
+export function useVerifyKudosAward() {
+    const qc = useQueryClient();
+
+    return useMutation<
+        { giftID: string; verificationStatus: string },
+        Error,
+        { giftID: string; action: KudosAwardVerdict }
+    >({
+        mutationFn: ({ giftID, action }) =>
+            apiMutate<
+                { giftID: string; verificationStatus: string },
+                { action: KudosAwardVerdict }
+            >(`/kudos/awards/${giftID}/verify`, 'put', { action }),
+        onSuccess: (result) => {
+            qc.invalidateQueries({ queryKey: ['kudos-awards'] });
+            qc.invalidateQueries({ queryKey: ['kudos-history'] });
+            pushAlert({
+                type: 'success',
+                message:
+                    result.verificationStatus === 'verified'
+                        ? 'Award verified.'
+                        : 'Award rejected — kudos returned.'
+            });
+        },
+        onError: (err) => {
+            pushAlert({ type: 'danger', message: extractErrMessage(err) });
+        }
+    });
+}

--- a/src/shared/api/queries/kudosAwards.ts
+++ b/src/shared/api/queries/kudosAwards.ts
@@ -1,0 +1,51 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { apiGet } from '@/shared/api/apiClient';
+import type { UserDTO } from '@/shared/api/types';
+
+export type KudosAwardStatusFilter =
+    | 'pending'
+    | 'verified'
+    | 'rejected'
+    | 'all';
+
+export type KudosAwardDTO = {
+    id: number;
+    giftID: string;
+    amount: number;
+    title?: string | null;
+    description?: string | null;
+    attachments: string[];
+    verificationStatus: 'pending' | 'verified' | 'rejected' | null;
+    verifiedByID: number | null;
+    createdAt: string;
+    recipient?: Pick<UserDTO, 'id' | 'username' | 'avatar' | 'kudos'> | null;
+    giver?: Pick<UserDTO, 'id' | 'username' | 'avatar' | 'kudos'> | null;
+};
+
+export const qkKudosAwards = {
+    infinite: (status: KudosAwardStatusFilter = 'pending') =>
+        ['kudos-awards', 'infinite', status] as const
+};
+
+export function useKudosAwardsInfinite(
+    status: KudosAwardStatusFilter = 'pending',
+    pageSize = 25
+) {
+    return useInfiniteQuery({
+        queryKey: qkKudosAwards.infinite(status),
+        queryFn: async ({ pageParam }) =>
+            apiGet<{
+                data: KudosAwardDTO[];
+                nextCursor?: number;
+                limit: number;
+            }>('/kudos/awards', {
+                params: {
+                    status,
+                    cursor: pageParam,
+                    limit: pageSize
+                }
+            }),
+        initialPageParam: undefined as number | undefined,
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined
+    });
+}

--- a/src/shared/api/queries/kudosHistory.ts
+++ b/src/shared/api/queries/kudosHistory.ts
@@ -7,14 +7,15 @@ export type KudosHistorySourceFilter =
     | 'donation'
     | 'feedback'
     | 'report'
-    | 'reward-offer';
+    | 'reward-offer'
+    | 'gift';
 
 export type KudosHistoryDTO = {
     id: number;
     delta: number;
     total?: number | null;
     createdAt: string;
-    source: 'donation' | 'feedback' | 'report' | 'reward-offer' | 'other';
+    source: 'donation' | 'feedback' | 'report' | 'reward-offer' | 'gift' | 'other';
     metadata?: Record<string, unknown> | null;
     actor?: UserDTO | null;
 };

--- a/tests/award-flow-demo.driver.ts
+++ b/tests/award-flow-demo.driver.ts
@@ -1,0 +1,221 @@
+import { test, type Page } from '@playwright/test';
+
+import { bootstrapAuth, CORS } from './utils/auth';
+
+const SHOT_DIR =
+    process.env.DEMO_SHOT_DIR ?? '/tmp/award-demo';
+
+const json = (body: unknown, status = 200) => ({
+    status,
+    headers: { 'content-type': 'application/json', ...CORS },
+    body: JSON.stringify(body)
+});
+
+const PNG_BYTES = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAUAAAADwCAYAAABxLb1rAAAAyklEQVR4nO3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgLcBHY4AAWn5UBIAAAAASUVORK5CYII=',
+    'base64'
+);
+
+const GIVER = {
+    id: 1,
+    email: 'e2e@example.com',
+    username: 'e2e-user',
+    kudos: 100,
+    settings: {},
+    tags: [],
+    location: null,
+    avatar: null,
+    badges: []
+};
+
+const RECIPIENT = {
+    id: 2,
+    email: 'bob@example.com',
+    username: 'bob',
+    kudos: 5,
+    settings: {},
+    tags: [],
+    location: null,
+    avatar: null,
+    badges: []
+};
+
+async function shot(page: Page, name: string) {
+    await page.waitForTimeout(400);
+    await page.screenshot({ path: `${SHOT_DIR}/${name}.png` });
+}
+
+test('demo: full award-kudos flow with screenshots', async ({ page }) => {
+    test.setTimeout(120_000);
+    await bootstrapAuth(page, 1);
+    await page.route(/\/users\/me(\?|$)/, (r) => r.fulfill(json(GIVER)));
+    await page.route(/\/users\/2(\?|$)/, (r) => r.fulfill(json(RECIPIENT)));
+    await page.route('**/kudos/award', (r) =>
+        r.fulfill(
+            json({
+                giftID: 'demo-gift-1',
+                amount: 25,
+                title: 'Helped me move houses',
+                description: 'Carried a couch up 4 floors',
+                attachments: [],
+                verificationStatus: 'pending',
+                recipientID: 2,
+                giverID: 1,
+                giverTotal: 75,
+                recipientTotal: 30
+            })
+        )
+    );
+
+    // 1 — bob's profile with the Award Kudos button + tooltip
+    await page.goto('/user/2');
+    await page.getByTestId('award-kudos').hover();
+    await page.waitForTimeout(500);
+    await shot(page, '01-profile-award-button-tooltip');
+
+    // 2 — modal with the form filled in + evidence attached
+    await page.getByTestId('award-kudos').click();
+    await page.locator('#title').fill('Helped me move houses');
+    await page.locator('#description').fill('Carried a couch up 4 floors');
+    await page.locator('#amount').fill('25');
+    await page.getByTestId('award-kudos-files').setInputFiles([
+        { name: 'couch.png', mimeType: 'image/png', buffer: PNG_BYTES },
+        { name: 'stairs.png', mimeType: 'image/png', buffer: PNG_BYTES }
+    ]);
+    await page.waitForTimeout(300);
+    await shot(page, '02-modal-filled');
+
+    // 3 — validation: over-balance amount
+    await page.locator('#amount').fill('500');
+    await page.getByTestId('award-kudos-submit').click();
+    await shot(page, '03-validation-over-balance');
+
+    // 4 — submit → success toast
+    await page.locator('#amount').fill('25');
+    await page.getByTestId('award-kudos-submit').click();
+    await page.getByText(/awarded 25 kudos!/i).waitFor();
+    await shot(page, '04-success-toast');
+
+    // 5 — kudos history with gift entries
+    await page.route('**/kudos/history*', (r) =>
+        r.fulfill(
+            json({
+                data: [
+                    {
+                        id: 2,
+                        delta: 25,
+                        total: 30,
+                        createdAt: new Date().toISOString(),
+                        source: 'gift',
+                        metadata: {
+                            giftID: 'demo-gift-1',
+                            title: 'Helped me move houses',
+                            description: 'Carried a couch up 4 floors',
+                            verificationStatus: 'pending',
+                            direction: 'received'
+                        },
+                        actor: GIVER
+                    },
+                    {
+                        id: 1,
+                        delta: -10,
+                        total: 5,
+                        createdAt: new Date(
+                            Date.now() - 86_400_000
+                        ).toISOString(),
+                        source: 'gift',
+                        metadata: {
+                            giftID: 'demo-gift-0',
+                            title: 'Thanks for the garden plants',
+                            verificationStatus: 'verified',
+                            direction: 'given'
+                        },
+                        actor: GIVER
+                    }
+                ],
+                limit: 10
+            })
+        )
+    );
+    await page.getByRole('button', { name: /^activity$/i }).click();
+    await page
+        .getByRole('button', { name: /view kudos reward history/i })
+        .click();
+    await page.getByTestId('kudos-gift-detail').first().waitFor();
+    await shot(page, '05-kudos-history-gifts');
+
+    // 6 — recipient notification in the bell
+    await page.route(/\/notifications(\?|$)/, (r) =>
+        r.fulfill(
+            json([
+                {
+                    id: 501,
+                    type: 'kudos-received',
+                    kudos: 25,
+                    userID: 1,
+                    user: { id: 1, username: 'e2e-user', avatar: null },
+                    isRead: false,
+                    isActedOn: false,
+                    createdAt: new Date().toISOString()
+                }
+            ])
+        )
+    );
+    await page.goto('/user/1');
+    await page.locator('button[aria-label="Notifications"]').click();
+    await page.getByText(/awarded you kudos/i).waitFor();
+    await shot(page, '06-notification-bell');
+
+    // 7 — admin proof verifier
+    await page.route(/\/users\/me(\?|$)/, (r) =>
+        r.fulfill(json({ ...GIVER, admin: true }))
+    );
+    await page.route('**/admin/reports*', (r) => r.fulfill(json([])));
+    await page.route(/\/feedback(\?|$)/, (r) => r.fulfill(json([])));
+    await page.route('**/kudos/awards?*', (r) =>
+        r.fulfill(
+            json({
+                data: [
+                    {
+                        id: 7,
+                        giftID: 'demo-gift-1',
+                        amount: 25,
+                        title: 'Helped me move houses',
+                        description: 'Carried a couch up 4 floors',
+                        attachments: [],
+                        verificationStatus: 'pending',
+                        verifiedByID: null,
+                        createdAt: new Date().toISOString(),
+                        recipient: {
+                            id: 2,
+                            username: 'bob',
+                            avatar: null,
+                            kudos: 30
+                        },
+                        giver: {
+                            id: 1,
+                            username: 'e2e-user',
+                            avatar: null,
+                            kudos: 75
+                        }
+                    }
+                ],
+                limit: 25
+            })
+        )
+    );
+    await page.route('**/kudos/awards/demo-gift-1/verify', (r) =>
+        r.fulfill(
+            json({ giftID: 'demo-gift-1', verificationStatus: 'verified' })
+        )
+    );
+    await page.goto('/admin');
+    await page.getByTestId('admin-tab-kudos-proofs').click();
+    await page.getByTestId('kudos-proof-card').waitFor();
+    await shot(page, '07-admin-proof-verifier');
+
+    // 8 — verify it → toast
+    await page.getByTestId('kudos-proof-verify').click();
+    await page.getByText(/award verified\./i).waitFor();
+    await shot(page, '08-admin-verified-toast');
+});

--- a/tests/award-kudos.spec.ts
+++ b/tests/award-kudos.spec.ts
@@ -1,0 +1,513 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+import { bootstrapAuth, CORS } from './utils/auth';
+
+const json = (body: unknown, status = 200) => ({
+    status,
+    headers: { 'content-type': 'application/json', ...CORS },
+    body: JSON.stringify(body)
+});
+
+// 1x1 red pixel PNG
+const PNG_BYTES = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==',
+    'base64'
+);
+
+const evidenceFile = (name = 'evidence.png') => ({
+    name,
+    mimeType: 'image/png',
+    buffer: PNG_BYTES
+});
+
+const GIVER = {
+    id: 1,
+    email: 'e2e@example.com',
+    username: 'e2e-user',
+    kudos: 100,
+    settings: {},
+    tags: [],
+    location: null,
+    avatar: null,
+    badges: []
+};
+
+const RECIPIENT = {
+    id: 2,
+    email: 'bob@example.com',
+    username: 'bob',
+    kudos: 5,
+    settings: {},
+    tags: [],
+    location: null,
+    avatar: null,
+    badges: []
+};
+
+/** Mocked session: current user (id 1, 100 kudos) viewing bob (id 2). */
+async function setupAwardPage(page: Page) {
+    await bootstrapAuth(page, 1);
+    // page routes take precedence over bootstrapAuth's context catch-all
+    await page.route(/\/users\/me(\?|$)/, (route) =>
+        route.fulfill(json(GIVER))
+    );
+    await page.route(/\/users\/2(\?|$)/, (route) =>
+        route.fulfill(json(RECIPIENT))
+    );
+}
+
+async function openAwardModal(page: Page) {
+    await page.goto('/user/2');
+    await page.getByTestId('award-kudos').click();
+    await expect(
+        page.getByRole('heading', { name: /award kudos to bob/i })
+    ).toBeVisible();
+}
+
+test.describe('Award kudos — entry points and tooltip', () => {
+    test('profile of another user shows the Award Kudos button with the explanatory hover tooltip', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await page.goto('/user/2');
+
+        const awardButton = page.getByTestId('award-kudos');
+        await expect(awardButton).toBeVisible();
+
+        // hover → tooltip explains awards are for past gifts / off-site help
+        await awardButton.hover();
+        const tooltip = page.getByTestId('kudos-info-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText(/past gifts/i);
+        await expect(tooltip).toContainText(/outside\s+the website/i);
+    });
+
+    test('own profile does not offer awarding kudos to yourself', async ({
+        page
+    }) => {
+        await bootstrapAuth(page, 1);
+        await page.goto('/user/1');
+        await expect(page.getByTestId('edit-profile')).toBeVisible();
+        await expect(page.getByTestId('award-kudos')).toHaveCount(0);
+    });
+
+    test('modal shows the giver balance and the tooltip on the info icon', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await openAwardModal(page);
+
+        await expect(page.getByTestId('award-kudos-balance')).toContainText(
+            'You have 100 kudos'
+        );
+
+        await page.getByTestId('kudos-info-trigger').hover();
+        await expect(page.getByTestId('kudos-info-tooltip')).toContainText(
+            /past gifts/i
+        );
+    });
+});
+
+test.describe('Award kudos — form validation', () => {
+    test('rejects empty title, non-positive and over-balance amounts', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await openAwardModal(page);
+
+        // Empty form
+        await page.getByTestId('award-kudos-submit').click();
+        await expect(page.getByText(/title is required/i)).toBeVisible();
+        await expect(
+            page.getByText(/enter how many kudos to award/i)
+        ).toBeVisible();
+
+        await page.locator('#title').fill('Helped me fix my bike');
+
+        // Zero amount
+        await page.locator('#amount').fill('0');
+        await page.getByTestId('award-kudos-submit').click();
+        await expect(
+            page.getByText(/kudos must be a positive whole number/i)
+        ).toBeVisible();
+
+        // More than the giver's balance
+        await page.locator('#amount').fill('500');
+        await page.getByTestId('award-kudos-submit').click();
+        await expect(
+            page.getByText(/you only have 100 kudos/i)
+        ).toBeVisible();
+
+        // Too-short title
+        await page.locator('#title').fill('ab');
+        await page.locator('#amount').fill('10');
+        await page.getByTestId('award-kudos-submit').click();
+        await expect(
+            page.getByText(/title must be at least 3 characters/i)
+        ).toBeVisible();
+    });
+
+    test('photo evidence can be attached, previewed and removed', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await openAwardModal(page);
+
+        const fileInput = page.getByTestId('award-kudos-files');
+        await fileInput.setInputFiles([
+            evidenceFile('one.png'),
+            evidenceFile('two.png')
+        ]);
+        await expect(page.getByTestId('award-kudos-preview')).toHaveCount(2);
+
+        await page.getByTestId('award-kudos-remove-0').click();
+        await expect(page.getByTestId('award-kudos-preview')).toHaveCount(1);
+
+        // Exceeding the 5-photo cap surfaces an error and keeps the previous selection
+        await fileInput.setInputFiles([
+            evidenceFile('a.png'),
+            evidenceFile('b.png'),
+            evidenceFile('c.png'),
+            evidenceFile('d.png'),
+            evidenceFile('e.png')
+        ]);
+        await expect(
+            page.getByTestId('award-kudos-file-error')
+        ).toContainText(/max 5 photos/i);
+        await expect(page.getByTestId('award-kudos-preview')).toHaveCount(1);
+    });
+});
+
+test.describe('Award kudos — submission', () => {
+    test('submits a multipart award, shows the success toast and closes the modal', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+
+        const awardRequest = new Promise<string>((resolve) => {
+            page.route('**/kudos/award', async (route: Route) => {
+                const req = route.request();
+                const bodyBuffer = req.postDataBuffer();
+                await route.fulfill(
+                    json({
+                        giftID: 'e2e-gift-1',
+                        amount: 25,
+                        title: 'Helped me move houses',
+                        description: 'Carried a couch up 4 floors',
+                        attachments: ['/uploads/kudos/evidence.webp'],
+                        verificationStatus: 'pending',
+                        recipientID: 2,
+                        giverID: 1,
+                        giverTotal: 75,
+                        recipientTotal: 30
+                    })
+                );
+                resolve(
+                    bodyBuffer
+                        ? bodyBuffer.toString('utf8')
+                        : req.postData() ?? ''
+                );
+            });
+        });
+
+        await openAwardModal(page);
+
+        await page.locator('#title').fill('Helped me move houses');
+        await page
+            .locator('#description')
+            .fill('Carried a couch up 4 floors');
+        await page.locator('#amount').fill('25');
+        await page
+            .getByTestId('award-kudos-files')
+            .setInputFiles([evidenceFile()]);
+        await expect(page.getByTestId('award-kudos-preview')).toHaveCount(1);
+
+        await page.getByTestId('award-kudos-submit').click();
+
+        const requestBody = await awardRequest;
+        expect(requestBody).toContain('name="recipientID"');
+        expect(requestBody).toContain('\r\n2\r\n');
+        expect(requestBody).toContain('name="title"');
+        expect(requestBody).toContain('Helped me move houses');
+        expect(requestBody).toContain('name="description"');
+        expect(requestBody).toContain('Carried a couch up 4 floors');
+        expect(requestBody).toContain('name="amount"');
+        expect(requestBody).toContain('\r\n25\r\n');
+        expect(requestBody).toContain('name="files[0]"');
+        expect(requestBody).toContain('filename="evidence.png"');
+
+        await expect(page.getByText(/awarded 25 kudos!/i)).toBeVisible();
+        await expect(
+            page.getByRole('heading', { name: /award kudos to bob/i })
+        ).toHaveCount(0);
+    });
+
+    test('surfaces a server rejection (e.g. insufficient balance) as an error toast and keeps the modal open', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await page.route('**/kudos/award', (route) =>
+            route.fulfill(
+                json(
+                    {
+                        message:
+                            'Not enough kudos: you have 100, tried to award 100000.'
+                    },
+                    400
+                )
+            )
+        );
+
+        await openAwardModal(page);
+        await page.locator('#title').fill('Nice try');
+        await page.locator('#amount').fill('100');
+        await page.getByTestId('award-kudos-submit').click();
+
+        await expect(page.getByText(/not enough kudos/i)).toBeVisible();
+        await expect(
+            page.getByRole('heading', { name: /award kudos to bob/i })
+        ).toBeVisible();
+    });
+});
+
+test.describe('Award kudos — transactions history', () => {
+    test('kudos history renders gift entries with verification status, evidence and direction', async ({
+        page
+    }) => {
+        await setupAwardPage(page);
+        await page.route('**/kudos/history*', (route) =>
+            route.fulfill(
+                json({
+                    data: [
+                        {
+                            id: 2,
+                            delta: 25,
+                            total: 30,
+                            createdAt: new Date().toISOString(),
+                            source: 'gift',
+                            metadata: {
+                                giftID: 'g-1',
+                                title: 'Helped me move houses',
+                                description: 'Carried a couch',
+                                attachments: ['/uploads/kudos/evidence.webp'],
+                                verificationStatus: 'pending',
+                                direction: 'received'
+                            },
+                            actor: GIVER
+                        },
+                        {
+                            id: 1,
+                            delta: -10,
+                            total: 5,
+                            createdAt: new Date().toISOString(),
+                            source: 'gift',
+                            metadata: {
+                                giftID: 'g-0',
+                                title: 'Thanks for the plants',
+                                verificationStatus: 'verified',
+                                direction: 'given'
+                            },
+                            actor: GIVER
+                        }
+                    ],
+                    limit: 10
+                })
+            )
+        );
+
+        await page.goto('/user/2');
+        await page.getByRole('button', { name: /^activity$/i }).click();
+        await page
+            .getByRole('button', { name: /view kudos reward history/i })
+            .click();
+
+        await expect(page.getByTestId('kudos-gift-detail')).toHaveCount(2);
+        await expect(page.getByText('+25 Kudos')).toBeVisible();
+        await expect(page.getByText('-10 Kudos')).toBeVisible();
+        await expect(
+            page.getByText(/kudos awarded to you for a past gift/i)
+        ).toBeVisible();
+        await expect(
+            page.getByText(/you awarded kudos for a past gift/i)
+        ).toBeVisible();
+        await expect(
+            page.getByTestId('kudos-gift-verification').filter({
+                hasText: /pending verification/i
+            })
+        ).toBeVisible();
+        await expect(
+            page.getByTestId('kudos-gift-verification').filter({
+                hasText: /^Verified$/
+            })
+        ).toBeVisible();
+
+        // The "Kudos awards" filter narrows to gift sources
+        await expect(
+            page.locator('select option[value="gift"]')
+        ).toHaveCount(1);
+    });
+});
+
+test.describe('Award kudos — recipient notification', () => {
+    test('notification bell attributes the award to the giver and shows the amount', async ({
+        page
+    }) => {
+        await bootstrapAuth(page, 1);
+        await page.route(/\/notifications(\?|$)/, (route) =>
+            route.fulfill(
+                json([
+                    {
+                        id: 501,
+                        type: 'kudos-received',
+                        kudos: 25,
+                        userID: 3,
+                        user: { id: 3, username: 'alice', avatar: null },
+                        isRead: false,
+                        isActedOn: false,
+                        createdAt: new Date().toISOString()
+                    }
+                ])
+            )
+        );
+
+        await page.goto('/user/1');
+        await page.locator('button[aria-label="Notifications"]').click();
+
+        await expect(
+            page.getByText(/alice awarded you kudos/i)
+        ).toBeVisible();
+        await expect(
+            page.getByText(/you received 25 kudos!/i)
+        ).toBeVisible();
+    });
+});
+
+test.describe('Award kudos — admin proof verifier', () => {
+    const PENDING_AWARD = {
+        id: 7,
+        giftID: 'g-7',
+        amount: 25,
+        title: 'Helped me move houses',
+        description: 'Carried a couch up 4 floors',
+        attachments: ['/uploads/kudos/evidence.webp'],
+        verificationStatus: 'pending',
+        verifiedByID: null,
+        createdAt: new Date().toISOString(),
+        recipient: { id: 2, username: 'bob', avatar: null, kudos: 30 },
+        giver: { id: 1, username: 'e2e-user', avatar: null, kudos: 75 }
+    };
+
+    async function setupAdmin(page: Page) {
+        await bootstrapAuth(page, 1);
+        await page.route(/\/users\/me(\?|$)/, (route) =>
+            route.fulfill(json({ ...GIVER, admin: true }))
+        );
+        await page.route('**/admin/reports*', (route) =>
+            route.fulfill(json([]))
+        );
+        await page.route(/\/feedback(\?|$)/, (route) =>
+            route.fulfill(json([]))
+        );
+    }
+
+    test('lists pending awards with evidence and verifies one', async ({
+        page
+    }) => {
+        await setupAdmin(page);
+        await page.route('**/kudos/awards?*', (route) =>
+            route.fulfill(json({ data: [PENDING_AWARD], limit: 25 }))
+        );
+
+        const verifyRequest = new Promise<string>((resolve) => {
+            page.route('**/kudos/awards/g-7/verify', async (route) => {
+                await route.fulfill(
+                    json({ giftID: 'g-7', verificationStatus: 'verified' })
+                );
+                resolve(route.request().postData() ?? '');
+            });
+        });
+
+        await page.goto('/admin');
+        await page.getByTestId('admin-tab-kudos-proofs').click();
+
+        const card = page.getByTestId('kudos-proof-card');
+        await expect(card).toBeVisible();
+        await expect(card).toContainText('25 Kudos');
+        await expect(card).toContainText('Helped me move houses');
+        await expect(card).toContainText('e2e-user');
+        await expect(card).toContainText('bob');
+        await expect(card.locator('img')).toHaveCount(1);
+        await expect(page.getByTestId('kudos-proof-status')).toContainText(
+            'pending'
+        );
+
+        await page.getByTestId('kudos-proof-verify').click();
+
+        const body = await verifyRequest;
+        expect(body).toContain('"action":"verify"');
+        await expect(page.getByText(/award verified\./i)).toBeVisible();
+    });
+
+    test('rejecting an award asks for confirmation and reports the refund', async ({
+        page
+    }) => {
+        await setupAdmin(page);
+        await page.route('**/kudos/awards?*', (route) =>
+            route.fulfill(json({ data: [PENDING_AWARD], limit: 25 }))
+        );
+
+        const rejectRequest = new Promise<string>((resolve) => {
+            page.route('**/kudos/awards/g-7/verify', async (route) => {
+                await route.fulfill(
+                    json({ giftID: 'g-7', verificationStatus: 'rejected' })
+                );
+                resolve(route.request().postData() ?? '');
+            });
+        });
+
+        let confirmMessage = '';
+        page.on('dialog', (dialog) => {
+            confirmMessage = dialog.message();
+            dialog.accept();
+        });
+
+        await page.goto('/admin');
+        await page.getByTestId('admin-tab-kudos-proofs').click();
+        await page.getByTestId('kudos-proof-reject').click();
+
+        const body = await rejectRequest;
+        expect(body).toContain('"action":"reject"');
+        expect(confirmMessage).toMatch(/25 kudos will be returned/i);
+        await expect(
+            page.getByText(/award rejected — kudos returned\./i)
+        ).toBeVisible();
+    });
+
+    test('dismissing the reject confirmation leaves the award untouched', async ({
+        page
+    }) => {
+        await setupAdmin(page);
+        await page.route('**/kudos/awards?*', (route) =>
+            route.fulfill(json({ data: [PENDING_AWARD], limit: 25 }))
+        );
+
+        let verifyCalled = false;
+        await page.route('**/kudos/awards/g-7/verify', async (route) => {
+            verifyCalled = true;
+            await route.fulfill(
+                json({ giftID: 'g-7', verificationStatus: 'rejected' })
+            );
+        });
+
+        page.on('dialog', (dialog) => dialog.dismiss());
+
+        await page.goto('/admin');
+        await page.getByTestId('admin-tab-kudos-proofs').click();
+        await page.getByTestId('kudos-proof-reject').click();
+
+        await expect(page.getByTestId('kudos-proof-status')).toContainText(
+            'pending'
+        );
+        expect(verifyCalled).toBe(false);
+    });
+});

--- a/tests/award-kudos.spec.ts
+++ b/tests/award-kudos.spec.ts
@@ -80,6 +80,7 @@ test.describe('Award kudos — entry points and tooltip', () => {
         await expect(tooltip).toBeVisible();
         await expect(tooltip).toContainText(/past gifts/i);
         await expect(tooltip).toContainText(/outside\s+the website/i);
+        await expect(tooltip).toContainText(/freely given/i);
     });
 
     test('own profile does not offer awarding kudos to yourself', async ({
@@ -91,14 +92,14 @@ test.describe('Award kudos — entry points and tooltip', () => {
         await expect(page.getByTestId('award-kudos')).toHaveCount(0);
     });
 
-    test('modal shows the giver balance and the tooltip on the info icon', async ({
+    test('modal explains kudos are freely given and shows the tooltip on the info icon', async ({
         page
     }) => {
         await setupAwardPage(page);
         await openAwardModal(page);
 
         await expect(page.getByTestId('award-kudos-balance')).toContainText(
-            'You have 100 kudos'
+            /freely given/i
         );
 
         await page.getByTestId('kudos-info-trigger').hover();
@@ -109,10 +110,30 @@ test.describe('Award kudos — entry points and tooltip', () => {
 });
 
 test.describe('Award kudos — form validation', () => {
-    test('rejects empty title, non-positive and over-balance amounts', async ({
+    test('rejects empty title and non-positive amounts (no balance cap — kudos are freely given)', async ({
         page
     }) => {
         await setupAwardPage(page);
+
+        let awardCalled = false;
+        await page.route('**/kudos/award', (route) => {
+            awardCalled = true;
+            return route.fulfill(
+                json({
+                    giftID: 'g-x',
+                    amount: 500,
+                    title: 'Helped me fix my bike',
+                    description: null,
+                    attachments: [],
+                    verificationStatus: 'pending',
+                    recipientID: 2,
+                    giverID: 1,
+                    giverTotal: 100,
+                    recipientTotal: 505
+                })
+            );
+        });
+
         await openAwardModal(page);
 
         // Empty form
@@ -131,13 +152,6 @@ test.describe('Award kudos — form validation', () => {
             page.getByText(/kudos must be a positive whole number/i)
         ).toBeVisible();
 
-        // More than the giver's balance
-        await page.locator('#amount').fill('500');
-        await page.getByTestId('award-kudos-submit').click();
-        await expect(
-            page.getByText(/you only have 100 kudos/i)
-        ).toBeVisible();
-
         // Too-short title
         await page.locator('#title').fill('ab');
         await page.locator('#amount').fill('10');
@@ -145,6 +159,13 @@ test.describe('Award kudos — form validation', () => {
         await expect(
             page.getByText(/title must be at least 3 characters/i)
         ).toBeVisible();
+
+        // Amounts above the giver's own kudos are allowed — freely given
+        await page.locator('#title').fill('Helped me fix my bike');
+        await page.locator('#amount').fill('500');
+        await page.getByTestId('award-kudos-submit').click();
+        await expect(page.getByText(/awarded 500 kudos!/i)).toBeVisible();
+        expect(awardCalled).toBe(true);
     });
 
     test('photo evidence can be attached, previewed and removed', async ({
@@ -242,19 +263,13 @@ test.describe('Award kudos — submission', () => {
         ).toHaveCount(0);
     });
 
-    test('surfaces a server rejection (e.g. insufficient balance) as an error toast and keeps the modal open', async ({
+    test('surfaces a server rejection as an error toast and keeps the modal open', async ({
         page
     }) => {
         await setupAwardPage(page);
         await page.route('**/kudos/award', (route) =>
             route.fulfill(
-                json(
-                    {
-                        message:
-                            'Not enough kudos: you have 100, tried to award 100000.'
-                    },
-                    400
-                )
+                json({ message: 'You cannot award kudos to yourself.' }, 400)
             )
         );
 
@@ -263,7 +278,9 @@ test.describe('Award kudos — submission', () => {
         await page.locator('#amount').fill('100');
         await page.getByTestId('award-kudos-submit').click();
 
-        await expect(page.getByText(/not enough kudos/i)).toBeVisible();
+        await expect(
+            page.getByText(/cannot award kudos to yourself/i)
+        ).toBeVisible();
         await expect(
             page.getByRole('heading', { name: /award kudos to bob/i })
         ).toBeVisible();
@@ -477,9 +494,9 @@ test.describe('Award kudos — admin proof verifier', () => {
 
         const body = await rejectRequest;
         expect(body).toContain('"action":"reject"');
-        expect(confirmMessage).toMatch(/25 kudos will be returned/i);
+        expect(confirmMessage).toMatch(/25 kudos will be removed/i);
         await expect(
-            page.getByText(/award rejected — kudos returned\./i)
+            page.getByText(/award rejected — kudos revoked\./i)
         ).toBeVisible();
     });
 

--- a/tests/award-kudos.spec.ts
+++ b/tests/award-kudos.spec.ts
@@ -92,15 +92,11 @@ test.describe('Award kudos — entry points and tooltip', () => {
         await expect(page.getByTestId('award-kudos')).toHaveCount(0);
     });
 
-    test('modal explains kudos are freely given and shows the tooltip on the info icon', async ({
+    test('modal shows the explanatory tooltip on the info trigger', async ({
         page
     }) => {
         await setupAwardPage(page);
         await openAwardModal(page);
-
-        await expect(page.getByTestId('award-kudos-balance')).toContainText(
-            /freely given/i
-        );
 
         await page.getByTestId('kudos-info-trigger').hover();
         await expect(page.getByTestId('kudos-info-tooltip')).toContainText(


### PR DESCRIPTION
## What

Frontend for the peer **Award Kudos** flow (companion to Kudos-League/kudos-server#25).

- **Award Kudos** button on other users' profiles, with a hover tooltip explaining awards document past gifts / help that happened outside the website (there's also a compact "What is this?" trigger inside the modal).
- `AwardKudosModal`: title, description, kudos amount and photographic evidence with previews/removal, submitted as multipart to `POST /kudos/award`. Amounts aren't capped by the giver's balance — kudos are freely given; the balance-cap validation is kept commented as a future blocking condition (paired with the commented debit server-side).
- Kudos history renders `gift` entries: direction, evidence thumbnails, verification badge, plus a "Kudos awards" filter.
- Notification bell/history attribute the award to the giver and show the amount.
- Admin panel **Kudos Proofs** tab: review evidence, **Verify** or **Reject & revoke** pending awards (revoke removes the kudos from the recipient).

## Testing

- `tests/award-kudos.spec.ts` (mocked project): 12 tests — tooltip, self-award exclusion, form validation, file attach/preview/remove/cap, multipart request body, server-error toast, history rendering, notifications, admin verify/reject/dismiss flows. **12/12 pass**; rest of the mocked suite unaffected.
- `yarn build` clean; unit tests pass.
- `tests/award-flow-demo.driver.ts` is a screenshot/demo driver (not picked up by the test glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)